### PR TITLE
Avoid hardcoding java home path

### DIFF
--- a/labs/lab2/README.md
+++ b/labs/lab2/README.md
@@ -150,7 +150,7 @@ First you need to get the DrJava source code. Run:
 4. Tell ant where Java 8 is
 
     ```
-    export JAVA8_HOME=/opt/oracle-jdk-bin-1.8.0.45/
+    export JAVA8_HOME=$(java-config --jdk-home)
     ```
 
 5. Recompile DrJava by running the command


### PR DESCRIPTION
Should keep the lab tutorial up to date in case of java updates. Assumes that java8 is the current working version, which it ideally should be for all the servers for at least a few years. One little caveat is that java-config is gentoo specific.
